### PR TITLE
feat: add film-simulation camera UI and APK packaging guide (Samsung S22+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,58 +7,41 @@
 - 拍照後套用顆粒與漏光效果
 - 匯出 JPG
 
-## 本機開發
+## 一鍵準備 Android 打包環境
 
 ```bash
-npm install
-npm run dev
+./scripts/package-apk.sh
 ```
 
-在手機測試時，請使用 HTTPS（相機 API 需要安全環境），或直接打包成 Android App。
+腳本會自動執行：
 
-## 打包成 Android APK（建議給 Samsung S22+）
+1. `npm install`
+2. `npm run build`
+3. 安裝 Capacitor 套件
+4. `npx cap init`（若尚未初始化）
+5. `npx cap add android`（若尚未建立 Android 平台）
+6. `npx cap sync android`
 
-1. 安裝依賴
+## 產出 APK（Samsung S22+）
 
-```bash
-npm install
-npm install @capacitor/core @capacitor/cli @capacitor/android
-```
-
-2. 建立前端產物
-
-```bash
-npm run build
-```
-
-3. 初始化 Capacitor（第一次）
-
-```bash
-npx cap init film.camera.app "Film Camera" --web-dir=dist
-```
-
-4. 新增 Android 平台
-
-```bash
-npx cap add android
-```
-
-5. 同步資源
-
-```bash
-npx cap sync android
-```
-
-6. 用 Android Studio 開啟並產出 APK
+腳本跑完後：
 
 ```bash
 npx cap open android
 ```
 
-之後在 Android Studio：
+接著在 Android Studio：
 
 - 選擇 `Build > Build Bundle(s) / APK(s) > Build APK(s)`
 - 安裝到 Samsung S22+ 測試
+
+## 若你在公司內網遇到 npm 403
+
+若安裝 `@capacitor/*` 出現 403（套件策略限制），請在可連到 npm registry 的網路環境執行 `./scripts/package-apk.sh`，或請管理員開放以下套件：
+
+- `@capacitor/core`
+- `@capacitor/cli`
+- `@capacitor/android`
 
 ## Samsung S22+ 測試建議
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,68 @@
-# React + Vite
+# Film Camera APK (Samsung S22+ 優先)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+這個專案是一個 React + Vite 底片模擬相機，提供：
 
-Currently, two official plugins are available:
+- 後鏡頭優先啟動（`facingMode: environment`）
+- 4 種底片風格（Kodak Gold / Fuji Superia / CineStill 800T / B&W）
+- 拍照後套用顆粒與漏光效果
+- 匯出 JPG
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## 本機開發
 
-## Expanding the ESLint configuration
+```bash
+npm install
+npm run dev
+```
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+在手機測試時，請使用 HTTPS（相機 API 需要安全環境），或直接打包成 Android App。
+
+## 打包成 Android APK（建議給 Samsung S22+）
+
+1. 安裝依賴
+
+```bash
+npm install
+npm install @capacitor/core @capacitor/cli @capacitor/android
+```
+
+2. 建立前端產物
+
+```bash
+npm run build
+```
+
+3. 初始化 Capacitor（第一次）
+
+```bash
+npx cap init film.camera.app "Film Camera" --web-dir=dist
+```
+
+4. 新增 Android 平台
+
+```bash
+npx cap add android
+```
+
+5. 同步資源
+
+```bash
+npx cap sync android
+```
+
+6. 用 Android Studio 開啟並產出 APK
+
+```bash
+npx cap open android
+```
+
+之後在 Android Studio：
+
+- 選擇 `Build > Build Bundle(s) / APK(s) > Build APK(s)`
+- 安裝到 Samsung S22+ 測試
+
+## Samsung S22+ 測試建議
+
+- Android 13/14 皆可
+- 首次開啟需允許相機權限
+- 建議使用後鏡頭主攝進行測試
+- 若畫面黑屏，確認其他 App 沒有占用相機

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "apk:prepare": "bash ./scripts/package-apk.sh"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/scripts/package-apk.sh
+++ b/scripts/package-apk.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_ID="film.camera.app"
+APP_NAME="Film Camera"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "[ERROR] npm not found. Please install Node.js first."
+  exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "[ERROR] npx not found. Please install Node.js first."
+  exit 1
+fi
+
+echo "[1/6] Installing web dependencies..."
+npm install
+
+echo "[2/6] Building web bundle..."
+npm run build
+
+echo "[3/6] Installing Capacitor packages..."
+npm install @capacitor/core @capacitor/cli @capacitor/android
+
+if [ ! -f "capacitor.config.ts" ] && [ ! -f "capacitor.config.json" ]; then
+  echo "[4/6] Initializing Capacitor..."
+  npx cap init "$APP_ID" "$APP_NAME" --web-dir=dist
+else
+  echo "[4/6] Capacitor already initialized."
+fi
+
+if [ ! -d "android" ]; then
+  echo "[5/6] Adding Android platform..."
+  npx cap add android
+else
+  echo "[5/6] Android platform already exists."
+fi
+
+echo "[6/6] Syncing web assets to Android..."
+npx cap sync android
+
+echo "Done."
+echo "Next steps:"
+echo "  1) npx cap open android"
+echo "  2) Android Studio > Build > Build APK(s)"

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,127 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.film-app {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #2f2f2f 0%, #111 50%, #050505 100%);
+  color: #f6f1e9;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1rem;
+  box-sizing: border-box;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.camera-panel,
+.preview-panel {
+  border: 1px solid #474747;
+  border-radius: 16px;
+  background: rgba(20, 20, 20, 0.92);
+  padding: 1rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+h1,
+h2 {
+  margin: 0;
+}
+
+.subtitle {
+  margin-top: 0.5rem;
+  color: #c5bdaf;
+}
+
+.camera-frame {
+  margin-top: 1rem;
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #000;
+}
+
+.camera-view {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.status {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.62);
+  font-size: 1rem;
+}
+
+.status.error {
+  color: #ff9f9f;
+}
+
+.film-row {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.film-chip {
+  background: #232323;
+  border: 1px solid #454545;
+  color: #efe6d8;
+  border-radius: 12px;
+  padding: 0.6rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.film-chip span {
+  font-size: 0.78rem;
+  color: #cfc2b5;
+}
+
+.film-chip.active {
+  border-color: #f2c46c;
+  box-shadow: 0 0 0 1px #f2c46c;
+}
+
+.actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.capture,
+.download {
+  flex: 1;
+  border-radius: 999px;
+  border: none;
+  padding: 0.75rem;
+  font-size: 1rem;
+}
+
+.capture {
+  background: #f2c46c;
+  color: #1a1a1a;
+}
+
+.download {
+  background: #4f79ff;
+  color: white;
+}
+
+.preview-image {
+  width: 100%;
+  border-radius: 12px;
+  margin-top: 0.75rem;
+}
+
+.hidden-canvas {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .film-app {
+    grid-template-columns: 1fr;
   }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,226 +1,183 @@
-import { useEffect, useRef, useState } from 'react';
-import ForceGraph2D from 'react-force-graph-2d';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import './App.css';
+
+const FILM_PRESETS = [
+  {
+    id: 'kodak-gold',
+    name: 'Kodak Gold',
+    description: '暖色、柔和高光',
+    videoFilter: 'saturate(1.15) contrast(1.08) brightness(1.04) sepia(0.14) hue-rotate(-6deg)',
+    grainOpacity: 0.1,
+    lightLeak: 'rgba(255, 166, 71, 0.15)'
+  },
+  {
+    id: 'fuji-superia',
+    name: 'Fuji Superia',
+    description: '偏綠調、街拍感',
+    videoFilter: 'saturate(1.08) contrast(1.13) brightness(1.02) hue-rotate(6deg)',
+    grainOpacity: 0.09,
+    lightLeak: 'rgba(145, 255, 184, 0.12)'
+  },
+  {
+    id: 'cinestill-800t',
+    name: 'CineStill 800T',
+    description: '夜景藍冷調',
+    videoFilter: 'saturate(1.05) contrast(1.16) brightness(0.94) hue-rotate(14deg)',
+    grainOpacity: 0.14,
+    lightLeak: 'rgba(62, 142, 255, 0.14)'
+  },
+  {
+    id: 'bw-classic',
+    name: 'B&W Classic',
+    description: '黑白銀鹽風格',
+    videoFilter: 'grayscale(1) contrast(1.2) brightness(1.05)',
+    grainOpacity: 0.12,
+    lightLeak: 'rgba(255, 255, 255, 0.05)'
+  }
+];
 
 export default function App() {
-  const [graphData, setGraphData] = useState({ nodes: [], links: [] });
-  const [keyword, setKeyword] = useState('狗');
-  const [loading, setLoading] = useState(false);
-  const [addMode, setAddMode] = useState(false);
-  const [inputPos, setInputPos] = useState({ x: window.innerWidth / 2 - 100, y: 150 });
-  const [inputValue, setInputValue] = useState('');
-  const [allLinks, setAllLinks] = useState([]);
-  const [history, setHistory] = useState([]);
-  const [showPanel, setShowPanel] = useState(false);
-  const fgRef = useRef();
-
-  const userData = useRef(JSON.parse(localStorage.getItem('userGraphData') || '{}'));
-  const deletedData = useRef(JSON.parse(localStorage.getItem('deletedGraphData') || '{}'));
-
-  const fetchGraph = async (centerWord) => {
-    setLoading(true);
-    try {
-      const res = await fetch(`https://api.conceptnet.io/c/zh/${encodeURIComponent(centerWord)}`);
-      const data = await res.json();
-
-      const customTerms = userData.current[centerWord] || [];
-      const deletedTerms = new Set(deletedData.current[centerWord] || []);
-
-      const relatedEdges = data.edges
-        .filter((edge) => {
-          const endLabel = edge.end?.label || edge.end?.term;
-          return (
-            endLabel &&
-            endLabel !== centerWord &&
-            /^[一-龥]+$/.test(endLabel) &&
-            !deletedTerms.has(endLabel)
-          );
-        })
-        .slice(0, 20);
-
-      const allRelated = Array.from(
-        new Set([
-          ...relatedEdges.map((e) => e.end?.label || e.end?.term),
-          ...customTerms
-        ])
-      ).filter((term) => !deletedTerms.has(term));
-
-      const newNodes = [
-        { id: centerWord, main: true },
-        ...allRelated.map((r) => ({ id: r }))
-      ];
-
-      const newLinks = [
-        ...relatedEdges.map((edge) => ({
-          source: centerWord,
-          target: edge.end?.label || edge.end?.term,
-          weight: Math.max(1, edge.weight * 2)
-        })),
-        ...customTerms
-          .filter((term) => !deletedTerms.has(term))
-          .map((term) => ({
-            source: centerWord,
-            target: term,
-            weight: 4
-          }))
-      ];
-
-      setGraphData({ nodes: newNodes, links: newLinks });
-      setAllLinks(allRelated);
-
-      if (fgRef.current) {
-        fgRef.current.d3ReheatSimulation();
-      }
-    } catch (e) {
-      console.error('探索失敗', e);
-    }
-    setLoading(false);
-  };
+  const videoRef = useRef(null);
+  const previewCanvasRef = useRef(null);
+  const captureCanvasRef = useRef(null);
+  const [activeFilm, setActiveFilm] = useState(FILM_PRESETS[0]);
+  const [cameraReady, setCameraReady] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [lastPhoto, setLastPhoto] = useState('');
 
   useEffect(() => {
-    fetchGraph(keyword);
+    let stream;
+
+    const initCamera = async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            facingMode: { ideal: 'environment' },
+            width: { ideal: 1920 },
+            height: { ideal: 1080 }
+          },
+          audio: false
+        });
+
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+          setCameraReady(true);
+        }
+      } catch (error) {
+        console.error(error);
+        setErrorMessage('相機啟動失敗，請確認瀏覽器已允許相機權限。');
+      }
+    };
+
+    initCamera();
+
+    return () => {
+      if (stream) {
+        stream.getTracks().forEach((track) => track.stop());
+      }
+    };
   }, []);
 
-  const handleClickNode = (node) => {
-    if (addMode) return;
-    setHistory((prev) => [...prev, keyword]);
-    fetchGraph(node.id);
-    setKeyword(node.id);
-  };
+  const filmFilter = useMemo(() => activeFilm.videoFilter, [activeFilm]);
 
-  const addCustomRelation = () => {
-    if (!inputValue.trim()) return;
-    const current = keyword;
-    const newTerm = inputValue.trim();
+  const paintFilmEffect = (ctx, width, height, preset) => {
+    const imageData = ctx.getImageData(0, 0, width, height);
+    const data = imageData.data;
 
-    userData.current[current] = userData.current[current] || [];
-    if (!userData.current[current].includes(newTerm)) {
-      userData.current[current].push(newTerm);
+    for (let i = 0; i < data.length; i += 4) {
+      const grain = (Math.random() - 0.5) * 255 * preset.grainOpacity;
+      data[i] = Math.min(255, Math.max(0, data[i] + grain));
+      data[i + 1] = Math.min(255, Math.max(0, data[i + 1] + grain));
+      data[i + 2] = Math.min(255, Math.max(0, data[i + 2] + grain));
     }
-    localStorage.setItem('userGraphData', JSON.stringify(userData.current));
 
-    deletedData.current[current] = (deletedData.current[current] || []).filter(t => t !== newTerm);
-    localStorage.setItem('deletedGraphData', JSON.stringify(deletedData.current));
+    ctx.putImageData(imageData, 0, 0);
 
-    setInputValue('');
-    setAddMode(false);
-    setInputPos(null);
-    fetchGraph(current);
+    const leakGradient = ctx.createRadialGradient(width * 0.9, height * 0.05, 0, width * 0.9, height * 0.05, width * 0.8);
+    leakGradient.addColorStop(0, preset.lightLeak);
+    leakGradient.addColorStop(1, 'rgba(0,0,0,0)');
+
+    ctx.fillStyle = leakGradient;
+    ctx.fillRect(0, 0, width, height);
   };
 
-  const deleteAnyRelation = (term) => {
-    const current = keyword;
-    deletedData.current[current] = deletedData.current[current] || [];
-    if (!deletedData.current[current].includes(term)) {
-      deletedData.current[current].push(term);
+  const capturePhoto = () => {
+    if (!videoRef.current || !captureCanvasRef.current) {
+      return;
     }
-    localStorage.setItem('deletedGraphData', JSON.stringify(deletedData.current));
 
-    fetchGraph(current);
+    const video = videoRef.current;
+    const canvas = captureCanvasRef.current;
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+      return;
+    }
+
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+
+    ctx.filter = filmFilter;
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    paintFilmEffect(ctx, canvas.width, canvas.height, activeFilm);
+
+    const dataUrl = canvas.toDataURL('image/jpeg', 0.95);
+    setLastPhoto(dataUrl);
   };
 
-  const handleBack = () => {
-    if (history.length === 0) return;
-    const prev = [...history];
-    const last = prev.pop();
-    setHistory(prev);
-    setKeyword(last);
-    fetchGraph(last);
+  const downloadPhoto = () => {
+    if (!lastPhoto) return;
+
+    const link = document.createElement('a');
+    link.href = lastPhoto;
+    link.download = `film-camera-${activeFilm.id}-${Date.now()}.jpg`;
+    link.click();
   };
 
   return (
-    <div style={{ position: 'relative', width: '100vw', height: '100vh' }}>
-      <div style={{ position: 'absolute', zIndex: 1, top: 20, left: 20, display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
-        <input
-          value={keyword}
-          onChange={(e) => setKeyword(e.target.value)}
-          placeholder="輸入關鍵字"
-          style={{ fontSize: '1rem', padding: '0.5rem', border: '1px solid #ccc', borderRadius: '4px', outline: 'none' }}
-        />
-        <button
-          onClick={() => fetchGraph(keyword)}
-          style={{ padding: '0.5rem 1rem', backgroundColor: '#4CAF50', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
-        >探索</button>
-        <button
-          onClick={handleBack}
-          disabled={history.length === 0}
-          style={{ padding: '0.5rem 1rem', backgroundColor: history.length === 0 ? '#ccc' : '#2196F3', color: 'white', border: 'none', borderRadius: '4px', cursor: history.length === 0 ? 'not-allowed' : 'pointer' }}
-        >← 返回</button>
-        <button
-          onClick={() => setAddMode(true)}
-          style={{ padding: '0.5rem 1rem', backgroundColor: '#f39c12', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
-        >➕ 新增關聯</button>
-        <button
-          onClick={() => setShowPanel(!showPanel)}
-          style={{ padding: '0.5rem 1rem', backgroundColor: '#888', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
-        >{showPanel ? '▶️ 收起編輯區' : '📌 編輯區'}</button>
-      </div>
+    <main className="film-app">
+      <section className="camera-panel">
+        <h1>底片模擬相機</h1>
+        <p className="subtitle">已優先使用後鏡頭（Samsung S22+ 可直接測試）</p>
 
-      <ForceGraph2D
-        ref={fgRef}
-        graphData={graphData}
-        nodeLabel="id"
-        onNodeClick={handleClickNode}
-        linkDistance={(link) => 300 / Math.pow(link.weight || 1, 1.5)}
-        cooldownTicks={80}
-        enableNodeDrag
-        enableZoomInteraction
-        enablePanInteraction
-        d3Force="charge"
-        d3ForceConfig={{ charge: -250 }}
-        nodeCanvasObject={(node, ctx, globalScale) => {
-          try {
-            if (!node || node.x == null || node.y == null || isNaN(node.x) || isNaN(node.y)) return;
-            const label = node.id;
-            const fontSize = (node.main ? 16 : 12) / globalScale;
-            ctx.font = `${fontSize}px sans-serif`;
-            ctx.fillStyle = node.main ? 'red' : 'black';
-            ctx.textAlign = 'center';
-            ctx.textBaseline = 'middle';
-            ctx.fillText(label, node.x, node.y);
-          } catch {}
-        }}
-        nodePointerAreaPaint={(node, color, ctx) => {
-          try {
-            if (!node || node.x == null || node.y == null || isNaN(node.x) || isNaN(node.y)) return;
-            ctx.fillStyle = color;
-            const size = node.main ? 20 : 10;
-            ctx.beginPath();
-            ctx.arc(node.x, node.y, size, 0, 2 * Math.PI, false);
-            ctx.fill();
-          } catch {}
-        }}
-      />
-
-      {addMode && (
-        <input
-          style={{ position: 'absolute', left: inputPos.x, top: inputPos.y, fontSize: '16px', padding: '4px', zIndex: 10, border: '1px solid #ccc', borderRadius: '4px' }}
-          autoFocus
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyDown={(e) => { if (e.key === 'Enter') addCustomRelation(); }}
-          placeholder="輸入新詞按 Enter"
-        />
-      )}
-
-      {showPanel && (
-        <div style={{ position: 'absolute', top: 60, right: 0, width: '33vw', maxWidth: 300, background: '#fff', padding: 8, borderRadius: '8px 0 0 8px', maxHeight: '70vh', overflowY: 'auto', overflowX: 'auto' }}>
-          <strong>關鍵詞：</strong>{keyword}
-          <div style={{ marginTop: 8 }}>
-            {allLinks.map((term) => (
-              <div key={term} style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
-                <span>{term}</span>
-                <button onClick={() => deleteAnyRelation(term)} style={{ marginLeft: 8 }}>🗑️</button>
-              </div>
-            ))}
-          </div>
+        <div className="camera-frame">
+          <video ref={videoRef} playsInline muted className="camera-view" style={{ filter: filmFilter }} />
+          <canvas ref={previewCanvasRef} className="hidden-canvas" aria-hidden="true" />
+          {!cameraReady && !errorMessage && <div className="status">啟動相機中...</div>}
+          {errorMessage && <div className="status error">{errorMessage}</div>}
         </div>
-      )}
 
-      <a
-        href="https://www.buymeacoffee.com/qooeego"
-        target="_blank"
-        style={{ position: 'absolute', bottom: 16, right: 16, textDecoration: 'none', fontSize: 16, fontWeight: 'bold', background: '#ffdd00', padding: '6px 12px', borderRadius: '6px', color: '#000' }}
-      >☕ Buy Me a Coffee</a>
-    </div>
+        <div className="film-row">
+          {FILM_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              type="button"
+              className={`film-chip ${activeFilm.id === preset.id ? 'active' : ''}`}
+              onClick={() => setActiveFilm(preset)}
+            >
+              <strong>{preset.name}</strong>
+              <span>{preset.description}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className="actions">
+          <button type="button" className="capture" onClick={capturePhoto} disabled={!cameraReady}>
+            拍照
+          </button>
+          <button type="button" className="download" onClick={downloadPhoto} disabled={!lastPhoto}>
+            下載照片
+          </button>
+        </div>
+      </section>
+
+      <section className="preview-panel">
+        <h2>最近拍攝</h2>
+        {lastPhoto ? <img src={lastPhoto} alt="最近拍攝成果" className="preview-image" /> : <p>還沒有照片，先拍一張吧。</p>}
+      </section>
+
+      <canvas ref={captureCanvasRef} className="hidden-canvas" aria-hidden="true" />
+    </main>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,23 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Inter', 'Noto Sans TC', system-ui, -apple-system, sans-serif;
+  line-height: 1.4;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  background: #050505;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
+  font: inherit;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous graph demo with a mobile-first film-simulation camera that can be tested on a Samsung S22+ using the rear camera.
- Provide an easy path to create an Android APK (Capacitor) so the camera API can be used in a secure context on device.
- Offer a small set of film presets and post-processing (grain + light leak) so photos can be exported as JPGs.

### Description
- Replaced the graph app with a camera experience in `src/App.jsx`, adding `FILM_PRESETS`, camera startup via `navigator.mediaDevices.getUserMedia({ facingMode: { ideal: 'environment' } })`, capture flow, `paintFilmEffect` (grain + light-leak), and `downloadPhoto` for JPG export.
- Reworked styles for a mobile camera layout in `src/App.css` and simplified global styles in `src/index.css` to avoid template conflicts.
- Updated `README.md` with local development commands and step-by-step APK packaging instructions using Capacitor (`npx cap init`, `npx cap add android`, `npx cap sync android`) and Samsung S22+ testing notes.

### Testing
- Ran the production build with `npm run build` (Vite) which completed successfully and produced `dist/` assets.
- No unit tests were added; the build step served as automated validation and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97aee558c83289ee1158e9523a222)